### PR TITLE
Implement -ignore_duplicates_module

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,8 @@ In addition to the general-purpose API documented above, TinyInst also implement
 
 `-indirect_instrumentation [none|local|global|auto]` which instrumentation to use for indirect jump/calls
 
+`-ignore_duplicates_module [module name]` Ensures only the first loaded instance of `[module name]` is instrumented, ignoring subsequent duplicates. Useful when instrumenting system libraries (e.g., `CoreAudio`) on macOS Sequoia and later, where multiple distinct libraries with the same name may be loaded.
+
 `-patch_return_addresses` - replaces return address with the original value, causes returns to be instrumented using whatever `-indirect_instrumentation` method is specified
 
 `-generate_unwind` - Generates stack unwinding data for instrumented code (for faster C++ exception handling). Note that it might not work correctly on some older Windows versions.

--- a/hook.md
+++ b/hook.md
@@ -23,7 +23,7 @@ It is expected that most hooking operations can be performed just using the brea
 
 If a hook needs to add additional assembly code, this can be done by implementing `WriteCodeBefore`/`WriteCodeAfter` methods of the hook class. Assembly code can be inserted by calling the `WriteCode` function with the buffer containing the assembly to be inserted. Note that both `WriteCodeBefore`/`WriteCodeAfter` get called during instrumentation time (before the function gets run) and, due to how `HookBeginEnd` is implemented, `WriteCodeAfter` can be called multiple times for a single hooked function.
 
-Once the hook classes have been implemented for each function the user wants to hook, the user can register them by calling `RegisterHook` method inside their clien's constructor.
+Once the hook classes have been implemented for each function the user wants to hook, the user can register them by calling `RegisterHook` method inside their client's constructor.
 
 ### Example
 

--- a/tinyinst.h
+++ b/tinyinst.h
@@ -292,6 +292,7 @@ class ModuleInfo {
   size_t code_size;
   bool loaded;
   bool instrumented;
+  bool ignore_duplicates;
   std::list<AddressRange> executable_ranges;
 
   size_t instrumented_code_size;


### PR DESCRIPTION
- Added the `-ignore_duplicates_module` option, which prevents subsequent modules of the same name from being re-instrumented. This is useful when instrumenting certain Apple frameworks which have the same name.
- Added a check to the Hook API to throw an error if the hook cannot be resolved. This provides feedback to the hook writer when the hook fails.