### PR TITLE
Make skipping re-instrumentation of duplicate modules the default behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,8 +186,6 @@ In addition to the general-purpose API documented above, TinyInst also implement
 
 `-indirect_instrumentation [none|local|global|auto]` which instrumentation to use for indirect jump/calls
 
-`-ignore_duplicates_module [module name]` Ensures only the first loaded instance of `[module name]` is instrumented, ignoring subsequent duplicates. Useful when instrumenting system libraries (e.g., `CoreAudio`) on macOS Sequoia and later, where multiple distinct libraries with the same name may be loaded.
-
 `-patch_return_addresses` - replaces return address with the original value, causes returns to be instrumented using whatever `-indirect_instrumentation` method is specified
 
 `-generate_unwind` - Generates stack unwinding data for instrumented code (for faster C++ exception handling). Note that it might not work correctly on some older Windows versions.

--- a/tinyinst.cpp
+++ b/tinyinst.cpp
@@ -43,7 +43,6 @@ ModuleInfo::ModuleInfo() {
   max_address = 0;
   loaded = false;
   instrumented = false;
-  ignore_duplicates = false;
   instrumented_code_local = NULL;
   instrumented_code_remote = NULL;
   instrumented_code_remote_previous = NULL;
@@ -846,12 +845,12 @@ void TinyInst::OnModuleInstrumented(ModuleInfo* module) {
       } else if(hook->GetFunctionOffset()) {
         address = (size_t)(module->module_header) + hook->GetFunctionOffset();
       } else {
-        FATAL("Hook specifies neithr function name nor offset");
+        FATAL("Hook specifies neither function name nor offset");
       }
       if(address) {
         resolved_hooks[address] = hook;
       } else {
-        FATAL("Could not resolve function %s in module %s", hook->GetFunctionName().c_str(), hook->GetModuleName().c_str());
+        WARN("Could not resolve function %s in module %s", hook->GetFunctionName().c_str(), hook->GetModuleName().c_str());
       }
     }
   }
@@ -1074,14 +1073,8 @@ void TinyInst::OnInstrumentModuleLoaded(void *module, ModuleInfo *target_module)
       target_module->module_header &&
       (target_module->module_header != (void *)module))
   {
-    if (target_module->ignore_duplicates) {
-      WARN("Skipping duplicate module %s.", target_module->module_name.c_str());
-      return;
-    } else {
-      WARN("Instrumented module loaded on a different address than seen previously\n"
-        "Module will need to be re-instrumented. Expect a drop in performance.");
-      ClearInstrumentation(target_module);
-    }
+    WARN("Skipping re-instrumentation of duplicate module %s.", target_module->module_name.c_str());
+    return;
   }
 
   target_module->module_header = (void *)module;
@@ -1269,9 +1262,6 @@ void TinyInst::Init(int argc, char **argv) {
   std::list <char *> module_names;
   GetOptionAll("-instrument_module", argc, argv, &module_names);
 
-  std::list <char *> ignored_duplicate_modules;
-  GetOptionAll("-ignore_duplicates_module", argc, argv, &ignored_duplicate_modules);
-
 #if defined(__APPLE__) && defined(ARM64)
   std::set <std::string> orig_uniq_mod_names;
   std::set <std::string> new_uniq_mod_names;
@@ -1311,11 +1301,6 @@ void TinyInst::Init(int argc, char **argv) {
   for (const auto module_name: module_names) {
     ModuleInfo *new_module = new ModuleInfo();
     new_module->module_name = module_name;
-    for (const auto& ignored_module : ignored_duplicate_modules) {
-      if (strcmp(ignored_module, module_name) == 0) {
-        new_module->ignore_duplicates = true;
-      }
-    }
     instrumented_modules.push_back(new_module);
     // SAY("--- %s\n", module_name);
   }

--- a/tinyinst.h
+++ b/tinyinst.h
@@ -292,7 +292,6 @@ class ModuleInfo {
   size_t code_size;
   bool loaded;
   bool instrumented;
-  bool ignore_duplicates;
   std::list<AddressRange> executable_ranges;
 
   size_t instrumented_code_size;


### PR DESCRIPTION
- Per Ivan's advice, I removed the `-ignore_duplicates_module` flag and implemented this as default behavior