### PR TITLE
Made skipping re-instrumentation of duplicate modules default behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,8 +188,6 @@ In addition to the general-purpose API documented above, TinyInst also implement
 
 `-indirect_instrumentation [none|local|global|auto]` which instrumentation to use for indirect jump/calls
 
-`-ignore_duplicates_module [module name]` Ensures only the first loaded instance of `[module name]` is instrumented, ignoring subsequent duplicates. Useful when instrumenting system libraries (e.g., `CoreAudio`) on macOS Sequoia and later, where multiple distinct libraries with the same name may be loaded.
-
 `-patch_return_addresses` - replaces return address with the original value, causes returns to be instrumented using whatever `-indirect_instrumentation` method is specified
 
 `-generate_unwind` - Generates stack unwinding data for instrumented code (for faster C++ exception handling). Note that it might not work correctly on some older Windows versions.

--- a/tinyinst.h
+++ b/tinyinst.h
@@ -293,7 +293,6 @@ class ModuleInfo {
   size_t code_size;
   bool loaded;
   bool instrumented;
-  bool ignore_duplicates;
   std::list<AddressRange> executable_ranges;
 
   size_t instrumented_code_size;


### PR DESCRIPTION
- Made ignoring re-instrumentation of duplicate modules the default behavior